### PR TITLE
Add coverage reports to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,7 @@
 /yarn-error.log
 yarn-debug.log*
 .yarn-integrity
+
+# Ignore SimpleCov coverage report generated files
+/coverage/*
+


### PR DESCRIPTION
SimpleCov generated coverage reports should not be included in the repository blob